### PR TITLE
feat (user removal): adds more flags for user removal

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -7,6 +7,8 @@
     shell: "{{ user.shell | default('/bin/bash') }}"
     groups: "{{ user.groups | default([]) }}"
     state: "{{ user.state | default('present') }}"
+    force: "{{ user.force | default('no') }}"
+    remove: "{{ user.remove | default('no') }}"
 
 - name: "Ensure SSH key for user is up to date"
   authorized_key:


### PR DESCRIPTION
Currently we loop over custom user attributes and map them
to user role of ansible. for removing a user it can be benfitial
if we can have remove and force attributes.

These attributes can help to remove user's home folder and related
files which are not removed by just stating `state=absent`