### PR TITLE
[fix] replace the deprecated include module with include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Add user"
-  include: "user.yml"
+  include_tasks: "user.yml"
   with_items: "{{ linux_users }}"
   loop_control:
     loop_var: "user"


### PR DESCRIPTION
The `include` module has been deprecated in Ansible 2.12, and completely removed in Ansible 2.16 (https://github.com/ansible/ansible/blob/v2.16.0/changelogs/CHANGELOG-v2.16.rst#removed-features-previously-deprecated).

Replacing it with `include_tasks` fixes the issue. It was introduced in Ansible 2.4 so this should not be a braking change (see: https://docs.ansible.com/ansible/2.9/modules/include_tasks_module.html).